### PR TITLE
Consistent parameter schema argument for registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
--   🐛 Fix the `run_cell` builtin to actually return the result. This does however bring back side effects of display output.
--   𝌭 Extend type for `parameters_model` is now correctly `Optional[Type["BaseModel"]]` so that you can extend a model for parameters in your own typed Python code. ✅ mypy
-
 ### Changed
 
--   💬🔬 Package is now called `chatlab`!
+-   🔄 Package named changed from `murkrow` to `chatlab`! 💬🔬
+-   🤓 Simplified the `register` methods of the `Conversation` and `FunctionRegistry` classes. The parameters `parameters_model` and `json_schema` are replaced by a single parameter `parameter_schema`, which can be a pydantic model or a JSON schema. This streamlines and simplifies the function registration process by accepting both pydantic models and JSON schema as parameter schemas in a single argument instead of two separate arguments. This reduces ambiguity and simplifies the implementation.
 -   💪🏻 Improved typing for messaging
 -   📝 Documentation improvements
 -   📜 When outputs and inputs are too big, allow scrolling instead of overflowing
+
+### Fixed
+
+-   🐛 Fixed the run_cell builtin to actually return the result. This reintroduces side effects of display output, meaning outputs from run_cell will now appear in the notebook and be visible to the Language Model as part of the run.
+-   ✅ Extended type for parameters_model is now correctly `Optional[Type["BaseModel"]]` so that you can extend a model for parameters in your own typed Python code. This is now mypy compliant.
 
 ## [0.13.0]
 

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -222,23 +222,16 @@ class Conversation:
             else:
                 self.messages.append(message)
 
-    def register(
-        self,
-        function: Callable,
-        parameters_model: Optional[Type["BaseModel"]] = None,
-        json_schema: Optional[dict] = None,
-    ):
+    def register(self, function: Callable, parameter_schema: Optional[Union[Type["BaseModel"], dict]] = None):
         """Register a function with the ChatLab instance.
 
         Args:
             function (Callable): The function to register.
 
-            parameters_model (BaseModel): The pydantic model to use for the function's parameters.
-
-            json_schema (dict): The JSON schema to use for the function's parameters.
+            schema (BaseModel or dict): The pydantic model or JSON schema to use for the function's parameters.
 
         """
-        full_schema = self.function_registry.register(function, parameters_model, json_schema)
+        full_schema = self.function_registry.register(function, parameter_schema)
 
         logger.debug("Created function with schema:")
         logger.debug(json.dumps(full_schema, indent=2))

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -228,7 +228,7 @@ class Conversation:
         Args:
             function (Callable): The function to register.
 
-            schema (BaseModel or dict): The pydantic model or JSON schema to use for the function's parameters.
+            parameter_schema (BaseModel or dict): The pydantic model or JSON schema for the function's parameters.
 
         """
         full_schema = self.function_registry.register(function, parameter_schema)

--- a/notebooks/openai-weather.ipynb
+++ b/notebooks/openai-weather.ipynb
@@ -282,12 +282,264 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4f194b40-2d75-4cb1-a709-47f0870f795a",
+   "metadata": {},
+   "source": [
+    "## FunctionRegistry variant"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "01b5bab9-816b-4caf-8a02-53fd0316eefd",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       " "
+      ],
+      "text/plain": [
+       " "
+      ]
+     },
+     "metadata": {
+      "text/markdown": {
+       "chatlab": {
+        "default": true
+       }
+      }
+     },
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vdom.v1+json": {
+       "attributes": {},
+       "children": [
+        {
+         "attributes": {},
+         "children": [
+          ".chatlab-chat-details summary > *  { display: inline; color: #27374D; }"
+         ],
+         "tagName": "style"
+        },
+        {
+         "attributes": {
+          "className": "chatlab-chat-details",
+          "style": {
+           "background": "#DDE6ED",
+           "borderRadius": "5px",
+           "padding": ".5rem 1rem"
+          }
+         },
+         "children": [
+          {
+           "attributes": {
+            "style": {
+             "color": "#27374D",
+             "cursor": "pointer"
+            }
+           },
+           "children": [
+            {
+             "attributes": {
+              "style": {
+               "color": "#9DB2BF",
+               "paddingLeft": "5px",
+               "paddingRight": "5px"
+              }
+             },
+             "children": [
+              "𝑓"
+             ],
+             "tagName": "span"
+            },
+            {
+             "attributes": {
+              "style": {
+               "color": "#27374D",
+               "paddingLeft": "5px",
+               "paddingRight": "5px"
+              }
+             },
+             "children": [
+              "Ran"
+             ],
+             "tagName": "span"
+            },
+            {
+             "attributes": {
+              "style": {
+               "fontFamily": "monospace",
+               "unicodeBidi": "embed",
+               "whiteSpace": "pre"
+              }
+             },
+             "children": [
+              "get_current_weather"
+             ],
+             "tagName": "span"
+            },
+            {
+             "attributes": {
+              "style": {
+               "fontFamily": "monospace",
+               "unicodeBidi": "embed",
+               "whiteSpace": "pre"
+              }
+             },
+             "children": [
+              ""
+             ],
+             "tagName": "span"
+            }
+           ],
+           "tagName": "summary"
+          },
+          {
+           "attributes": {
+            "style": {
+             "marginLeft": "10px",
+             "marginTop": "10px"
+            }
+           },
+           "children": [
+            {
+             "attributes": {},
+             "children": [
+              {
+               "attributes": {
+                "style": {
+                 "color": "#27374D",
+                 "fontWeight": "500",
+                 "marginBottom": "5px"
+                }
+               },
+               "children": [
+                "Input:"
+               ],
+               "tagName": "div"
+              },
+              {
+               "attributes": {
+                "style": {
+                 "background": "#F7F9FA",
+                 "color": "#27374D",
+                 "fontFamily": "monospace",
+                 "marginBottom": "10px",
+                 "padding": "10px",
+                 "unicodeBidi": "embed",
+                 "whiteSpace": "pre"
+                }
+               },
+               "children": [
+                "{\n  \"location\": \"Boston, MA\"\n}"
+               ],
+               "tagName": "div"
+              }
+             ],
+             "tagName": "div"
+            },
+            {
+             "attributes": {},
+             "children": [
+              {
+               "attributes": {
+                "style": {
+                 "color": "#27374D",
+                 "fontWeight": "500",
+                 "marginBottom": "5px"
+                }
+               },
+               "children": [
+                "Output:"
+               ],
+               "tagName": "div"
+              },
+              {
+               "attributes": {
+                "style": {
+                 "background": "#F7F9FA",
+                 "color": "#27374D",
+                 "fontFamily": "monospace",
+                 "marginBottom": "10px",
+                 "padding": "10px",
+                 "unicodeBidi": "embed",
+                 "whiteSpace": "pre"
+                }
+               },
+               "children": [
+                "'{\"location\": \"Boston, MA\", \"temperature\": \"72\", \"unit\": \"fahrenheit\", \"forecast\": [\"sunny\", \"windy\"]}'"
+               ],
+               "tagName": "div"
+              }
+             ],
+             "tagName": "div"
+            }
+           ],
+           "tagName": "div"
+          }
+         ],
+         "tagName": "details"
+        }
+       ],
+       "tagName": "div"
+      },
+      "text/html": [
+       "<div><style>.chatlab-chat-details summary &gt; *  { display: inline; color: #27374D; }</style><details style=\"background: #DDE6ED; border-radius: 5px; padding: .5rem 1rem\" className=\"chatlab-chat-details\"><summary style=\"color: #27374D; cursor: pointer\"><span style=\"color: #9DB2BF; padding-left: 5px; padding-right: 5px\">𝑓</span><span style=\"color: #27374D; padding-left: 5px; padding-right: 5px\">Ran</span><span style=\"font-family: monospace; unicode-bidi: embed; white-space: pre\">get_current_weather</span><span style=\"font-family: monospace; unicode-bidi: embed; white-space: pre\"></span></summary><div style=\"margin-left: 10px; margin-top: 10px\"><div><div style=\"color: #27374D; font-weight: 500; margin-bottom: 5px\">Input:</div><div style=\"background: #F7F9FA; color: #27374D; font-family: monospace; margin-bottom: 10px; padding: 10px; unicode-bidi: embed; white-space: pre\">{\n",
+       "  &quot;location&quot;: &quot;Boston, MA&quot;\n",
+       "}</div></div><div><div style=\"color: #27374D; font-weight: 500; margin-bottom: 5px\">Output:</div><div style=\"background: #F7F9FA; color: #27374D; font-family: monospace; margin-bottom: 10px; padding: 10px; unicode-bidi: embed; white-space: pre\">&#x27;{&quot;location&quot;: &quot;Boston, MA&quot;, &quot;temperature&quot;: &quot;72&quot;, &quot;unit&quot;: &quot;fahrenheit&quot;, &quot;forecast&quot;: [&quot;sunny&quot;, &quot;windy&quot;]}&#x27;</div></div></div></details></div>"
+      ],
+      "text/plain": [
+       "<chatlab.display.ChatFunctionCall at 0x10f74cf90>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/markdown": [
+       "The current weather in Boston, MA is 72°F and it is sunny and windy."
+      ],
+      "text/plain": [
+       "The current weather in Boston, MA is 72°F and it is sunny and windy."
+      ]
+     },
+     "metadata": {
+      "text/markdown": {
+       "chatlab": {
+        "default": true
+       }
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from chatlab import user, Conversation, FunctionRegistry\n",
+    "\n",
+    "weather_parameters = {\n",
+    "    \"type\": \"object\",\n",
+    "    \"properties\": {\n",
+    "        \"location\": {\n",
+    "            \"type\": \"string\",\n",
+    "            \"description\": \"The city and state, e.g. San Francisco, CA\",\n",
+    "        },\n",
+    "        \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n",
+    "    },\n",
+    "    \"required\": [\"location\"],\n",
+    "}\n",
+    "\n",
+    "\n",
+    "fr = FunctionRegistry()\n",
+    "fr.register(get_current_weather, weather_parameters)\n",
+    "\n",
+    "conversation = Conversation(function_registry=fr)\n",
+    "conversation.submit(user(\"What's the weather like in Boston?\"))"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/openai-weather.ipynb
+++ b/notebooks/openai-weather.ipynb
@@ -234,7 +234,7 @@
        "}</div></div><div><div style=\"color: #27374D; font-weight: 500; margin-bottom: 5px\">Output:</div><div style=\"background: #F7F9FA; color: #27374D; font-family: monospace; margin-bottom: 10px; padding: 10px; unicode-bidi: embed; white-space: pre\">&#x27;{&quot;location&quot;: &quot;Boston, MA&quot;, &quot;temperature&quot;: &quot;72&quot;, &quot;unit&quot;: &quot;fahrenheit&quot;, &quot;forecast&quot;: [&quot;sunny&quot;, &quot;windy&quot;]}&#x27;</div></div></div></details></div>"
       ],
       "text/plain": [
-       "<chatlab.display.ChatFunctionCall at 0x137948410>"
+       "<chatlab.display.ChatFunctionCall at 0x10f051d50>"
       ]
      },
      "metadata": {},
@@ -243,10 +243,10 @@
     {
      "data": {
       "text/markdown": [
-       "The current weather in Boston, MA is 72°F and it is sunny and windy."
+       "The current temperature in Boston, MA is 72°F. The weather is currently sunny and windy."
       ],
       "text/plain": [
-       "The current weather in Boston, MA is 72°F and it is sunny and windy."
+       "The current temperature in Boston, MA is 72°F. The weather is currently sunny and windy."
       ]
      },
      "metadata": {
@@ -264,23 +264,19 @@
     "\n",
     "conversation = Conversation()\n",
     "\n",
-    "weather_schema = {\n",
-    "    \"name\": \"get_current_weather\",\n",
-    "    \"description\": \"Get the current weather in a given location\",\n",
-    "    \"parameters\": {\n",
-    "        \"type\": \"object\",\n",
-    "        \"properties\": {\n",
-    "            \"location\": {\n",
-    "                \"type\": \"string\",\n",
-    "                \"description\": \"The city and state, e.g. San Francisco, CA\",\n",
-    "            },\n",
-    "            \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n",
+    "weather_parameters = {\n",
+    "    \"type\": \"object\",\n",
+    "    \"properties\": {\n",
+    "        \"location\": {\n",
+    "            \"type\": \"string\",\n",
+    "            \"description\": \"The city and state, e.g. San Francisco, CA\",\n",
     "        },\n",
-    "        \"required\": [\"location\"],\n",
+    "        \"unit\": {\"type\": \"string\", \"enum\": [\"celsius\", \"fahrenheit\"]},\n",
     "    },\n",
+    "    \"required\": [\"location\"],\n",
     "}\n",
     "\n",
-    "conversation.register(get_current_weather, json_schema=weather_schema)\n",
+    "conversation.register(get_current_weather, weather_parameters)\n",
     "\n",
     "conversation.submit(user(\"What's the weather like in Boston?\"))"
    ]


### PR DESCRIPTION
This simplifies the arguments to `register`, for both `Conversation` and `FunctionRegistry`, to pass the parameters model (`pydantic.BaseModel`) or a pure `dict` that is a parameter schema.

## `Conversation`

```python
from chatlab import user, Conversation

weather_parameters = {
    "type": "object",
    "properties": {
        "location": {
            "type": "string",
            "description": "The city and state, e.g. San Francisco, CA",
        },
        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
    },
    "required": ["location"],
}

conversation = Conversation()
conversation.register(get_current_weather, weather_parameters)
conversation.submit(user("What's the weather like in Boston?"))
```

## `FunctionRegistry`

```python
from chatlab import user, Conversation, FunctionRegistry

weather_parameters = {
    "type": "object",
    "properties": {
        "location": {
            "type": "string",
            "description": "The city and state, e.g. San Francisco, CA",
        },
        "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
    },
    "required": ["location"],
}


fr = FunctionRegistry()
fr.register(get_current_weather, weather_parameters)

conversation = Conversation(function_registry=fr)
conversation.submit(user("What's the weather like in Boston?"))
```