### PR TITLE
Remove auto continue option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   🔄 Package named changed from `murkrow` to `chatlab`! 💬🔬
+-   🔄 Package name changed from `murkrow` to `chatlab`! 💬🔬
 -   🤓 Simplified the `register` methods of the `Conversation` and `FunctionRegistry` classes. The parameters `parameters_model` and `json_schema` are replaced by a single parameter `parameter_schema`, which can be a pydantic model or a JSON schema. This streamlines and simplifies the function registration process by accepting both pydantic models and JSON schema as parameter schemas in a single argument instead of two separate arguments. This reduces ambiguity and simplifies the implementation.
 -   💪🏻 Improved typing for messaging
 -   📝 Documentation improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   🐛 Fixed the run_cell builtin to actually return the result. This reintroduces side effects of display output, meaning outputs from run_cell will now appear in the notebook and be visible to the Language Model as part of the run.
 -   ✅ Extended type for parameters_model is now correctly `Optional[Type["BaseModel"]]` so that you can extend a model for parameters in your own typed Python code. This is now mypy compliant.
 
+### Removed
+
+-   🚗 Took out the `auto_continue` option since it only applied to function calls and generally should be `True` for function call responses
+
 ## [0.13.0]
 
 ### Added

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -31,8 +31,6 @@ class Conversation:
 
         function_registry (FunctionRegistry): The function registry to use for the conversation.
 
-        auto_continue (bool): Whether to automatically continue the conversation after each message.
-
         allow_hallucinated_python (bool): Whether to include the built-in Python function when hallucinated by the model.
 
     Examples:
@@ -47,7 +45,6 @@ class Conversation:
     messages: List[Message]
     model: str
     function_registry: FunctionRegistry
-    auto_continue: bool
     allow_hallucinated_python: bool
 
     def __init__(
@@ -55,7 +52,6 @@ class Conversation:
         *initial_context: Union[Message, str],
         model="gpt-3.5-turbo-0613",
         function_registry: Optional[FunctionRegistry] = None,
-        auto_continue: bool = True,
         allow_hallucinated_python: bool = False,
     ):
         """Initialize a Conversation with an optional initial context of messages.
@@ -86,7 +82,6 @@ class Conversation:
 
         self.append(*initial_context)
         self.model = model
-        self.auto_continue = auto_continue
 
         self.allow_hallucinated_python = allow_hallucinated_python
 
@@ -98,14 +93,17 @@ class Conversation:
     @deprecated(
         deprecated_in="0.13.0", removed_in="1.0.0", current_version=__version__, details="Use `submit` instead."
     )
-    def chat(self, *messages: Union[Message, str], auto_continue: Optional[bool] = None):
+    def chat(
+        self,
+        *messages: Union[Message, str],
+    ):
         """Send messages to the chat model and display the response.
 
         Deprecated in 0.13.0, removed in 1.0.0. Use `submit` instead.
         """
-        return self.submit(*messages, auto_continue=auto_continue)
+        return self.submit(*messages)
 
-    def submit(self, *messages: Union[Message, str], auto_continue: Optional[bool] = None):
+    def submit(self, *messages: Union[Message, str]):
         """Send messages to the chat model and display the response.
 
         Side effects:
@@ -115,8 +113,6 @@ class Conversation:
 
         Args:
             messages (str | Message): One or more messages to send to the chat, can be strings or Message objects.
-
-            auto_continue (bool): Whether to continue the conversation after the messages are sent. Defaults to the
 
         """
         self.append(*messages)

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -197,18 +197,15 @@ class Conversation:
             # Include the response (or error) for the model
             self.append(fn_message)
 
-            # Choose whether to let the LLM continue from our function response
-            continuing = auto_continue if auto_continue is not None else self.auto_continue
-
-            if continuing:
-                # Automatically let the LLM continue from our function result
-                self.submit()
+            # Automatically let the LLM continue from our function result
+            self.submit()
             return
 
         # All other finish reasons are valid for regular assistant messages
 
         # Wrap up the previous assistant
-        self.messages.append(assistant(mark.message))
+        if mark is not None and mark.message.strip() != "":
+            self.messages.append(assistant(mark.message))
 
         if finish_reason == 'stop':
             return

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -197,7 +197,7 @@ class Conversation:
             # Include the response (or error) for the model
             self.append(fn_message)
 
-            # Automatically let the LLM continue from our function result
+            # Reply back to the LLM with the result of the function call, allow it to continue
             self.submit()
             return
 

--- a/notebooks/introduce-time.ipynb
+++ b/notebooks/introduce-time.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "import chatlab\n",
     "\n",
-    "conversation = chatlab.Conversation(auto_continue=True)\n",
+    "conversation = chatlab.Conversation()\n",
     "conversation.register(what_time)"
    ]
   },


### PR DESCRIPTION
Removes the auto_continue flag since it wasn't doing what it said it would -- automatically continuing. It was only intended for functions, which we've figured out can keep on going after the first call.