### PR TITLE
[py] create a rich traceback for LLM consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0]
+
+### Changed
+
+-   🐍🔙 Send a traceback to the LLM when an exception occurs in the builtin python interpreter
+
 ## [0.15.3]
+
+### Changed
 
 -   📦 Update description and classifiers for PyPI
 -   ❌ Remove unused packages
 
 ## [0.15.2]
+
+### Changed
 
 -   📦 Include universal wheels in build
 


### PR DESCRIPTION
The LLM wasn't grokking the final result object from when `result.success` was false. This sets up a tidy little traceback for the LLM.