### PR TITLE
Break out the OpenAI Chat Completions manifest creation out

### DIFF
--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -182,30 +182,6 @@ class Chat:
                         )
                         chat_function.display()
 
-                        #
-                        ### The model doesn't care, ignore this section of code. I've had it spit 100 `python` calls
-                        #
-                        # if function_call['name'] not in self.function_registry:
-                        #     # Append a system message for the model, then allow it to continue
-                        #     self.append(
-                        #         assistant_function_call(
-                        #             name=function_call['name'],
-                        #             # OpenAI requires arguments as part of their message even though the stream
-                        #             # will send them separately. We can't just not send them, so we send an empty
-                        #             # string.
-                        #             arguments='',
-                        #         )
-                        #     )
-                        #     self.append(system(f"Function `{function_call['name']}` not registered."))
-                        #     # The odd thing here is that ChatGPT will still be emitting. We need to tell it to stop.
-                        #     # Our only choice is to break, which interrupts the stream. This is the only way to
-                        #     # stop the model from continuing to emit.
-                        #     finish_reason = CHATLAB_EXIT_BAD_CALL
-
-                        #     chat_function.finished = True
-                        #     chat_function.set_state("Errored")
-                        #     break
-
                     if 'arguments' in function_call:
                         if chat_function is None:
                             raise ValueError("Function arguments provided without function name")

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -117,16 +117,6 @@ class Chat:
         """Send messages to the chat model and display the response."""
         return await self.submit(*messages)
 
-    def _prepare_chat_function_arguments(self):
-        """Prepare the chat function arguments for the OpenAI API."""
-        chat_function_arguments = dict()
-        if len(self.function_registry.function_definitions) > 0:
-            chat_function_arguments = dict(
-                functions=self.function_registry.function_definitions,
-                function_call="auto",
-            )
-        return chat_function_arguments
-
     async def submit(self, *messages: Union[Message, str]):
         """Send messages to the chat model and display the response.
 
@@ -145,13 +135,10 @@ class Chat:
         mark = Markdown()
         mark.display()
 
-        # Don't pass in functions if there are none
-        chat_function_arguments = self._prepare_chat_function_arguments()
-
         resp = openai.ChatCompletion.create(
             model=self.model,
             messages=self.messages,
-            **chat_function_arguments,
+            **self.function_registry.api_manifest(),
             stream=True,
         )
 

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -117,6 +117,16 @@ class Chat:
         """Send messages to the chat model and display the response."""
         return await self.submit(*messages)
 
+    def _prepare_chat_function_arguments(self):
+        """Prepare the chat function arguments for the OpenAI API."""
+        chat_function_arguments = dict()
+        if len(self.function_registry.function_definitions) > 0:
+            chat_function_arguments = dict(
+                functions=self.function_registry.function_definitions,
+                function_call="auto",
+            )
+        return chat_function_arguments
+
     async def submit(self, *messages: Union[Message, str]):
         """Send messages to the chat model and display the response.
 
@@ -136,12 +146,7 @@ class Chat:
         mark.display()
 
         # Don't pass in functions if there are none
-        chat_function_arguments = dict()
-        if len(self.function_registry.function_definitions) > 0:
-            chat_function_arguments = dict(
-                functions=self.function_registry.function_definitions,
-                function_call="auto",
-            )
+        chat_function_arguments = self._prepare_chat_function_arguments()
 
         resp = openai.ChatCompletion.create(
             model=self.model,

--- a/chatlab/registry.py
+++ b/chatlab/registry.py
@@ -201,6 +201,14 @@ class FunctionRegistry:
         chatlab_metadata = getattr(function, "chatlab_metadata", ChatlabMetadata())
         return chatlab_metadata
 
+    def api_manifest(self):
+        """Get the API manifest for the registry."""
+        if len(self.function_definitions) == 0:
+            # When there are no functions, we can't send an empty functions array to OpenAI
+            return {}
+
+        return {"functions": self.function_definitions, "function_call": "auto"}
+
     async def call(self, name: str, arguments: Optional[str] = None) -> Any:
         """Call a function by name with the given parameters."""
         function = self.get(name)

--- a/chatlab/registry.py
+++ b/chatlab/registry.py
@@ -201,13 +201,64 @@ class FunctionRegistry:
         chatlab_metadata = getattr(function, "chatlab_metadata", ChatlabMetadata())
         return chatlab_metadata
 
-    def api_manifest(self):
-        """Get the API manifest for the registry."""
+    def api_manifest(self, function_call_option: Union[str, dict] = "auto"):
+        """
+        Get a dictionary containing function definitions and calling options.
+        This is designed to be used with OpenAI's Chat Completion API, where the
+        dictionary can be passed as keyword arguments to set the `functions` and
+        `function_call` parameters.
+
+        The `functions` parameter is a list of dictionaries, each representing a
+        function that the model can call during the conversation. Each dictionary
+        has a `name`, `description`, and `parameters` key.
+
+        The `function_call` parameter sets the policy of when to call these functions:
+            - "auto": The model decides when to call a function (default).
+            - "none": The model generates a user-facing message without calling a function.
+            - {"name": "<insert-function-name>"}: Forces the model to call a specific function.
+
+        Args:
+            function_call_option (str or dict, optional): The policy for function calls.
+            Defaults to "auto".
+
+        Returns:
+            dict: A dictionary with keys "functions" and "function_call", which
+            can be passed as keyword arguments to `openai.ChatCompletion.create`.
+
+        Example usage:
+            >>> registry = FunctionRegistry()
+            >>> # Register functions here...
+            >>> manifest = registry.api_manifest()
+            >>> resp = openai.ChatCompletion.create(
+                    model="gpt-4.0-turbo",
+                    messages=[...],
+                    **manifest,
+                    stream=True,
+                )
+
+            >>> # To force a specific function to be called:
+            >>> manifest = registry.api_manifest({"name": "what_time"})
+            >>> resp = openai.ChatCompletion.create(
+                    model="gpt-4.0-turbo",
+                    messages=[...],
+                    **manifest,
+                    stream=True,
+                )
+
+            >>> # To generate a user-facing message without calling a function:
+            >>> manifest = registry.api_manifest("none")
+            >>> resp = openai.ChatCompletion.create(
+                    model="gpt-4.0-turbo",
+                    messages=[...],
+                    **manifest,
+                    stream=True,
+                )
+        """
         if len(self.function_definitions) == 0:
             # When there are no functions, we can't send an empty functions array to OpenAI
             return {}
 
-        return {"functions": self.function_definitions, "function_call": "auto"}
+        return {"functions": self.function_definitions, "function_call": function_call_option}
 
     async def call(self, name: str, arguments: Optional[str] = None) -> Any:
         """Call a function by name with the given parameters."""


### PR DESCRIPTION
Trying to make `submit` a little cleaner and easier to read by refactoring it and breaking it into more functions.