### PR TITLE
expand on the chat functions available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -   🪄 Introduced `make_magic` on a `Chat` so that you can use a current chat as a cell magic in IPython and Jupyter notebooks
 -   ⏩ Accept async functions as chat functions
 -   📗 New experimental builtin: Noteable. Create notebooks on Noteable like you can via ChatGPT Plugins with even more flexibility.
+-   🧩 Accept collections of functions to `Chat` and `FunctionRegistry` to register multiple functions at once
 
 ### Changed
 

--- a/chatlab/builtins/files.py
+++ b/chatlab/builtins/files.py
@@ -2,7 +2,10 @@
 import asyncio
 import os
 
+from chatlab.decorators import expose_exception_to_llm
 
+
+@expose_exception_to_llm
 async def list_files(directory: str) -> list[str]:
     """List all files in the given directory.
 
@@ -17,6 +20,7 @@ async def list_files(directory: str) -> list[str]:
     return files
 
 
+@expose_exception_to_llm
 async def get_file_size(file_path: str) -> int:
     """Get the size of the file in bytes asynchronously.
 
@@ -30,6 +34,7 @@ async def get_file_size(file_path: str) -> int:
     return size
 
 
+@expose_exception_to_llm
 async def is_file(file_path: str) -> bool:
     """Check if the given path points to a file asynchronously.
 
@@ -43,6 +48,7 @@ async def is_file(file_path: str) -> bool:
     return is_file
 
 
+@expose_exception_to_llm
 async def is_directory(directory: str) -> bool:
     """Check if the given path points to a directory asynchronously.
 

--- a/chatlab/builtins/files.py
+++ b/chatlab/builtins/files.py
@@ -1,0 +1,59 @@
+"""Built-in functions for file operations."""
+import asyncio
+import os
+
+
+async def list_files(directory: str) -> list[str]:
+    """List all files in the given directory.
+
+    Args:
+    - directory: str, the directory to list files from
+
+    Returns:
+    - list[str]: the list of files in the given directory
+
+    """
+    files = await asyncio.to_thread(os.listdir, directory)
+    return files
+
+
+async def get_file_size(file_path: str) -> int:
+    """Get the size of the file in bytes asynchronously.
+
+    Args:
+    - file_path: The path to the file
+
+    Returns:
+    - The size of the file in bytes
+    """
+    size = await asyncio.to_thread(os.path.getsize, file_path)
+    return size
+
+
+async def is_file(file_path: str) -> bool:
+    """Check if the given path points to a file asynchronously.
+
+    Args:
+    - file_path: The path to check
+
+    Returns:
+    - True if the path points to a file, False otherwise
+    """
+    is_file = await asyncio.to_thread(os.path.isfile, file_path)
+    return is_file
+
+
+async def is_directory(directory: str) -> bool:
+    """Check if the given path points to a directory asynchronously.
+
+    Args:
+    - directory: The path to check
+
+    Returns:
+    - True if the path points to a directory, False otherwise
+    """
+    is_directory = await asyncio.to_thread(os.path.isdir, directory)
+    return is_directory
+
+
+chat_functions = [list_files, get_file_size, is_file, is_directory]

--- a/chatlab/builtins/shell.py
+++ b/chatlab/builtins/shell.py
@@ -2,8 +2,11 @@
 import asyncio
 import subprocess
 
+from chatlab.decorators import expose_exception_to_llm
 
-async def run_shell_command(command: str) -> str:
+
+@expose_exception_to_llm
+async def run_shell_command(command: str):
     """Run a shell command and return the output.
 
     Args:
@@ -14,7 +17,7 @@ async def run_shell_command(command: str) -> str:
     """
     process = await asyncio.create_subprocess_shell(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = await process.communicate()
-    return stdout.decode().strip()
+    return process.returncode, stdout.decode().strip(), stderr.decode().strip()
 
 
 chat_functions = [run_shell_command]

--- a/chatlab/builtins/shell.py
+++ b/chatlab/builtins/shell.py
@@ -1,0 +1,20 @@
+"""Shell commands for ChatLab."""
+import asyncio
+import subprocess
+
+
+async def run_shell_command(command: str) -> str:
+    """Run a shell command and return the output.
+
+    Args:
+    - command: str, the shell command to execute
+
+    Returns:
+    - str: the output of the shell command
+    """
+    process = await asyncio.create_subprocess_shell(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    stdout, stderr = await process.communicate()
+    return stdout.decode().strip()
+
+
+chat_functions = [run_shell_command]

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -20,7 +20,6 @@ from .messaging import (
     ChatCompletion,
     Message,
     StreamCompletion,
-    assistant_function_call,
     human,
     is_full_choice,
     is_function_call,
@@ -101,6 +100,7 @@ class Chat:
         *initial_context: Union[Message, str],
         model="gpt-3.5-turbo-0613",
         function_registry: Optional[FunctionRegistry] = None,
+        chat_functions: Optional[List[Callable]] = None,
         allow_hallucinated_python: bool = False,
         python_hallucination_function: Optional[PythonHallucinationFunction] = None,
     ):
@@ -144,6 +144,9 @@ class Chat:
             self.function_registry = FunctionRegistry(python_hallucination_function=python_hallucination_function)
         else:
             self.function_registry = function_registry
+
+        if chat_functions is not None:
+            self.function_registry.register_functions(chat_functions)
 
     @deprecated(
         deprecated_in="0.13.0", removed_in="1.0.0", current_version=__version__, details="Use `submit` instead."

--- a/chatlab/registry.py
+++ b/chatlab/registry.py
@@ -42,7 +42,7 @@ Example usage:
 import asyncio
 import inspect
 import json
-from typing import Any, Callable, Optional, Type, Union, get_args, get_origin
+from typing import Any, Callable, Iterable, Optional, Type, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -183,6 +183,14 @@ class FunctionRegistry:
         self.__schemas[function.__name__] = final_schema
 
         return final_schema
+
+    def register_functions(self, functions: Union[Iterable[Callable], dict[str, Callable]]):
+        """Register a dictionary of functions."""
+        if isinstance(functions, dict):
+            functions = functions.values()
+
+        for function in functions:
+            self.register(function)
 
     def get(self, function_name) -> Optional[Callable]:
         """Get a function by name."""


### PR DESCRIPTION
* Make outputs more friendly in the Noteable Chat Functions
* Expose `NotebookClient.chat_functions` to get all the bound functions intended for the LLMs
* Accept collections of functions to `Chat` and `FunctionRegistry` to make it easy to register and work with big collections of functions.

```python
from chatlab import Chat
from chatlab.models import GPT_3_5_TURBO_16K_0613
from chatlab.builtins.noteable import NotebookClient

notebook = await NotebookClient.connect(file_id=file_id)

chat = Chat(
    model=GPT_3_5_TURBO_16K_0613,
    chat_functions=notebook.chat_functions(),
    python_hallucination_function=notebook.python
)

await chat("Critique this notebook")
```