### PR TITLE
get the message before flushing the buffer

### DIFF
--- a/chatlab/views/abstracts.py
+++ b/chatlab/views/abstracts.py
@@ -91,9 +91,10 @@ class BufferView(ABC):
 
     def flush(self):
         """Flushes the message buffer."""
+        message = self.get_message()
         self.buffer = self.create_buffer()
         self.active = False
-        return self.get_message()
+        return message
 
     def _ipython_display_(self):
         """Display the buffer."""

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -28,6 +28,17 @@ def test_assistant_message_get():
     }
 
 
+def test_assistant_message_flush():
+    amv = AssistantMessageView()
+    amv.append("test")
+    message = amv.flush()
+    assert amv.content == ""
+    assert message == {
+        "role": "assistant",
+        "content": "test",
+    }
+
+
 def test_assistant_function_call_view_creation():
     afcv = AssistantFunctionCallView("compute_pi")
     assert isinstance(afcv, AssistantFunctionCallView)


### PR DESCRIPTION
This was causing assistant messages to be blank in the history. :( Only an issue on the alpha release though!