### PR TITLE
Noteable client updates

### DIFF
--- a/chatlab/builtins/noteable.py
+++ b/chatlab/builtins/noteable.py
@@ -382,7 +382,23 @@ class NotebookClient:
     async def get_cell_ids(self):
         """Get a list of cell IDs."""
         rtu_client = await self.get_or_create_rtu_client()
-        return rtu_client.cell_ids
+
+        response = ""
+
+        for cell_id in rtu_client.cell_ids:
+            try:
+                _, cell = rtu_client.builder.get_cell(cell_id)
+                source = cell.source.strip()
+
+                if source.startswith("#ignore") or source.startswith("# ignore"):
+                    continue
+
+                response += f"{cell_id}\n"
+
+            except KeyError:
+                continue
+
+        return response
 
     async def shutdown(self):
         """Shutdown the notebook."""

--- a/chatlab/builtins/noteable.py
+++ b/chatlab/builtins/noteable.py
@@ -228,18 +228,15 @@ class NotebookClient:
 
     async def _get_llm_friendly_output(self, output: KernelOutput):
         """Get the output for a given output."""
-        content = output.content
+        content = output.content_for_llm
+        if content is None:
+            content = output.content
+
         if content is None:
             return None
 
         if output.type == "error":
             return await self._extract_error(content)
-
-        if 'text/llm+plain' in output.available_mimetypes:
-            # Fetch the specialized LLM+Plain directly
-            result = await self._extract_llm_plain(output)
-            if result is not None:
-                return result
 
         if content.mimetype == 'text/html':
             result = await self._extract_specific_mediatype(output, 'text/plain')

--- a/chatlab/builtins/noteable.py
+++ b/chatlab/builtins/noteable.py
@@ -20,7 +20,17 @@ logger.setLevel(logging.DEBUG)
 
 
 class NotebookClient:
-    """A notebook client for use with Noteable."""
+    """A notebook client for use with ChatLab and Noteable.
+
+    This class integrates with ChatLab to create, connect to, and manage notebooks on the Noteable platform.
+    It enables interactive experiments with OpenAI's chat models within a notebook environment.
+
+    Attributes:
+        api_client (APIClient): The API client for Noteable.
+        rtu_client (RTUClient): The Real-Time Update client for Noteable.
+        file_id (uuid.UUID): The unique identifier for the notebook file.
+        kernel_session (KernelSession): The kernel session associated with the notebook.
+    """
 
     api_client: APIClient
     rtu_client: Optional[RTUClient]

--- a/chatlab/builtins/noteable.py
+++ b/chatlab/builtins/noteable.py
@@ -322,7 +322,7 @@ class NotebookClient:
 
         return resp_text
 
-    async def get_cell(self, cell_id: str, with_outputs: bool = False):
+    async def get_cell(self, cell_id: str, with_outputs: bool = True):
         """Get a cell by ID."""
         rtu_client = await self.get_or_create_rtu_client()
         try:


### PR DESCRIPTION
* return clean list of cell IDs, ignoring those with #ignore first line
* better document the NotebookClient class
* handle content for llm directly
* surface a way to create a notebook and register with a FunctionRegistry
* always return outputs on `get_cell`