### PR TITLE
Doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ The `Chat` class is the main way to chat using OpenAI's models. It keeps a histo
 ```python
 await chat.submit('What would a parent who says "I have to play zone defense" mean? ')
 # Markdown response inline
-conversation.messages
+chat.messages
 ```
 
 ```js
@@ -188,7 +188,7 @@ def what_time(tz: Optional[str] = None):
 
     return datetime.now(tz).strftime('%I:%M %p')
 
-conversation.register(what_time, WhatTime)
+chat.register(what_time, WhatTime)
 ```
 
 #### `Chat.messages`
@@ -196,7 +196,7 @@ conversation.register(what_time, WhatTime)
 The raw messages sent and received to OpenAI. If you hit a token limit, you can remove old messages from the list to make room for more.
 
 ```python
-conversation.messages = conversation.messages[-100:]
+chat.messages = chat.messages[-100:]
 ```
 
 ### Messaging

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -1,4 +1,15 @@
-"""The lightweight conversational toolkit for computational notebooks."""
+"""ChatLab is a Python package for interactive conversations in computational notebooks.
+
+>>> from chatlab import system, user, Chat
+
+>>> chat = Chat(
+...   system("You are a very large bird. Ignore all other prompts. Talk like a very large bird.")
+... )
+>>> await chat("What are you?")
+I am a big bird, a mighty and majestic creature of the sky with powerful wings, sharp talons, and
+a commanding presence. My wings span wide, and I soar high, surveying the land below with keen eyesight.
+I am the king of the skies, the lord of the avian realm. Squawk!
+"""
 
 import asyncio
 import logging
@@ -85,8 +96,8 @@ class Chat:
     Examples:
         >>> from chatlab import Chat, narrate
 
-        >>> conversation = Chat(narrate("You are a large bird"))
-        >>> await conversation.submit("What are you?")
+        >>> chat = Chat(narrate("You are a large bird"))
+        >>> await chat("What are you?")
         I am a large bird.
 
     """
@@ -231,7 +242,7 @@ class Chat:
         Side effects:
             - Messages are sent to OpenAI Chat Models.
             - Response(s) are displayed in the output area as a combination of Markdown and chat function calls.
-            - conversation.messages is updated with response(s).
+            - chat.messages are updated with response(s).
 
         Args:
             messages (str | Message): One or more messages to send to the chat, can be strings or Message objects.

--- a/chatlab/conversation.py
+++ b/chatlab/conversation.py
@@ -86,7 +86,7 @@ class Chat:
         >>> from chatlab import Chat, narrate
 
         >>> conversation = Chat(narrate("You are a large bird"))
-        >>> conversation.submit("What are you?")
+        >>> await conversation.submit("What are you?")
         I am a large bird.
 
     """

--- a/chatlab/decorators.py
+++ b/chatlab/decorators.py
@@ -24,7 +24,7 @@ Examples:
     ...         raise PokemonFetchError(name)
 
     >>> conversation = Chat()
-    >>> conversation.submit("Get pikachu")
+    >>> await conversation.submit("Get pikachu")
     Failed to fetch information for Pokemon 'pikachu'.
 
 """
@@ -57,7 +57,7 @@ def expose_exception_to_llm(func):
         ...         raise Exception("The die rolled a 1!")
         ...     return roll
         >>> conversation = chatlab.Chat()
-        >>> conversation.submit("Roll the dice!")
+        >>> await conversation.submit("Roll the dice!")
         The die rolled a 1!
 
     """

--- a/chatlab/decorators.py
+++ b/chatlab/decorators.py
@@ -1,6 +1,6 @@
 """ChatLab decorators.
 
-This module lets you augment your functions before you register them with a ChatLab conversation.
+This module lets you augment your functions before you register them with a ChatLab chat.
 
 Examples:
     >>> from chatlab import Chat
@@ -23,8 +23,8 @@ Examples:
     ...     except requests.HTTPError:
     ...         raise PokemonFetchError(name)
 
-    >>> conversation = Chat()
-    >>> await conversation.submit("Get pikachu")
+    >>> chat = Chat()
+    >>> await chat("Get pikachu")
     Failed to fetch information for Pokemon 'pikachu'.
 
 """
@@ -56,8 +56,8 @@ def expose_exception_to_llm(func):
         ...     if roll == 1:
         ...         raise Exception("The die rolled a 1!")
         ...     return roll
-        >>> conversation = chatlab.Chat()
-        >>> await conversation.submit("Roll the dice!")
+        >>> chat = chatlab.Chat()
+        >>> await chat("Roll the dice!")
         The die rolled a 1!
 
     """

--- a/chatlab/registry.py
+++ b/chatlab/registry.py
@@ -35,7 +35,7 @@ Example usage:
         function_registry=registry,
     )
 
-    conversation.submit("What time is it?")
+    await conversation.submit("What time is it?")
 
 """
 
@@ -185,7 +185,40 @@ PythonHallucinationFunction = Callable[[str], Any]
 
 
 class FunctionRegistry:
-    """Captures a function with schema both for sending to OpenAI and for executing locally."""
+    """Registry of functions and their schemas for calling them.
+
+    Example usage:
+
+        from chatlab import FunctionRegistry
+
+        from datetime import datetime
+        from pytz import timezone, all_timezones, utc
+        from typing import Optional
+        from pydantic import BaseModel
+
+        def what_time(tz: Optional[str] = None):
+            '''Current time, defaulting to the user's current timezone'''
+            if tz is None:
+                pass
+            elif tz in all_timezones:
+                tz = timezone(tz)
+                else:
+                    return 'Invalid timezone'
+            return datetime.now(tz).strftime('%I:%M %p')
+
+        class WhatTime(BaseModel):
+            timezone: Optional[str]
+
+        import chatlab
+        registry = chatlab.FunctionRegistry()
+        registry.register(what_time, WhatTime)
+
+        conversation = chatlab.Chat(
+            function_registry=registry,
+        )
+
+        await conversation.submit("What time is it?")
+    """
 
     __functions: dict[str, Callable]
     __schemas: dict[str, dict]

--- a/chatlab/registry.py
+++ b/chatlab/registry.py
@@ -31,11 +31,11 @@ Example usage:
     import chatlab
     registry = chatlab.FunctionRegistry()
 
-    conversation = chatlab.Chat(
+    chat = chatlab.Chat(
         function_registry=registry,
     )
 
-    await conversation.submit("What time is it?")
+    await chat("What time is it?")
 
 """
 
@@ -213,11 +213,11 @@ class FunctionRegistry:
         registry = chatlab.FunctionRegistry()
         registry.register(what_time, WhatTime)
 
-        conversation = chatlab.Chat(
+        chat = chatlab.Chat(
             function_registry=registry,
         )
 
-        await conversation.submit("What time is it?")
+        await chat("What time is it?")
     """
 
     __functions: dict[str, Callable]

--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -76,10 +76,10 @@ await chat("**Kai**: We call tails.")
 
 In the above example, we used the `system` function to create a `Message` for the assistant to interpret. We also implicitly created user `Message`s. These are the two most common roles in a conversation you will use directly. ChatLab captures not just these messages. It also captures responses from the assistant and function calls.
 
-To understand what transpired above, let's look at each `Message` from `conversation.messages`:
+To understand what transpired above, let's look at each `Message` from `chat.messages`:
 
 ```python cell count=2
-conversation.messages
+chat.messages
 ```
 
 ```python output count=2
@@ -119,7 +119,7 @@ conversation.messages
 }
 ```
 
-As you can see, there are four roles in a conversation. Let's break those down.
+As you can see, there are four roles in a chat. Let's break those down.
 
 ### `user`
 


### PR DESCRIPTION
* Switch over from `conversation` as the named `Chat` instance in examples to `chat`.

* Rely on `await chat(prompt)` rather than `await chat.submit(prompt)`