### PR TITLE
build function schemas with pydantic `create_model`

### DIFF
--- a/chatlab/registry.py
+++ b/chatlab/registry.py
@@ -177,9 +177,6 @@ def generate_function_schema(
         parameters["required"] = []
 
     schema["parameters"] = parameters
-    # from rich import print as rprint
-
-    # breakpoint()
     return schema
 
 


### PR DESCRIPTION
This replaces the need for `process_type` and `process_parameter` to use a lot of the built-in parsing from pydantic's `create_model` function, allowing for function arguments with type annotations like sets, UUIDs, and other pydantic models themselves.