### PR TITLE
run CI tests on PRs and ignore mypy errors from last PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,12 @@
 name: Python package
 
-on: [push]
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/chatlab/registry.py
+++ b/chatlab/registry.py
@@ -130,7 +130,7 @@ def generate_function_schema(
     if isinstance(parameter_schema, dict):
         parameters = parameter_schema
     elif parameter_schema is not None:
-        parameters = parameter_schema.schema()
+        parameters = parameter_schema.schema()  # type: ignore
     else:
         # extract function parameters and their type annotations
         sig = inspect.signature(function)
@@ -161,9 +161,9 @@ def generate_function_schema(
         model = create_model(
             function.__name__,
             __config__=FunctionSchemaConfig,
-            **fields,
+            **fields,  # type: ignore
         )
-        parameters: dict = model.schema()
+        parameters: dict = model.schema()  # type: ignore
 
     if "properties" not in parameters:
         parameters["properties"] = {}


### PR DESCRIPTION
- https://github.com/rgbkrk/chatlab/pull/93 raised some errors during the merge to main:
```python
chatlab/registry.py:161: error: No overload variant of "create_model" matches argument types "str", "Type[FunctionSchemaConfig]", "Dict[str, Tuple[Any, ellipsis]]"  [call-overload]
chatlab/registry.py:161: note: Possible overload variants:
chatlab/registry.py:161: note:     def create_model(str, /, *, __config__: Optional[Type[BaseConfig]] = ..., __base__: None = ..., __module__: str = ..., __validators__: Dict[str, classmethod[Any, Any, Any]] = ..., __cls_kwargs__: Dict[str, Any] = ..., **field_definitions: Any) -> Type[BaseModel]
chatlab/registry.py:161: note:     def [Model <: BaseModel] create_model(str, /, *, __config__: Optional[Type[BaseConfig]] = ..., __base__: Union[Type[Model], Tuple[Type[Model], ...]], __module__: str = ..., __validators__: Dict[str, classmethod[Any, Any, Any]] = ..., __cls_kwargs__: Dict[str, Any] = ..., **field_definitions: Any) -> Type[Model]

chatlab/registry.py:166: error: Name "parameters" already defined on line 131  [no-redef]

Found 2 errors in 1 file (checked 23 source files)
```