### PR TITLE
import RTUClient from the real source

### DIFF
--- a/chatlab/builtins/noteable.py
+++ b/chatlab/builtins/noteable.py
@@ -7,7 +7,8 @@ from typing import Literal, Optional
 import httpx
 import orjson
 import ulid
-from origami.clients.api import APIClient, RTUClient
+from origami.clients.api import APIClient
+from origami.clients.rtu import RTUClient
 from origami.models.api.outputs import KernelOutput, KernelOutputContent
 from origami.models.kernels import KernelSession
 from origami.models.notebook import CodeCell, MarkdownCell, make_sql_cell


### PR DESCRIPTION
This was relying on an import polluting the API namespace (see https://github.com/noteable-io/origami/commit/5cc7c2e37cf7ab1feec3d9bad3e2af3f90358608#diff-a8038da466d15ede92da41b0f61145add59afe1fec514742de0dd7c221765e43L9). Now we're getting it from the right place.