### PR TITLE
disable vdom output

### DIFF
--- a/chatlab/display.py
+++ b/chatlab/display.py
@@ -105,5 +105,5 @@ class ChatFunctionCall(AutoDisplayer):
         )
         return {
             "text/html": vdom_component.to_html(),
-            "application/vdom.v1+json": vdom_component.to_dict(),
+            # "application/vdom.v1+json": vdom_component.to_dict(),
         }

--- a/chatlab/views/argument_buffer.py
+++ b/chatlab/views/argument_buffer.py
@@ -42,5 +42,5 @@ class ArgumentBuffer(BufferInterface):
         )
         return {
             "text/html": vdom_component.to_html(),
-            "application/vdom.v1+json": vdom_component.to_dict(),
+            # "application/vdom.v1+json": vdom_component.to_dict(),
         }


### PR DESCRIPTION
Since VS Code doesn't support `vdom` output properly, I'd like to disable it (for now).