### PR TITLE
loosen up the python and ipython deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9.0,<3.13"
-ipython = ">=7.0.0,<9.0.0"
+python = ">=3.9.0"
+ipython = ">=7.0.0"
 openai = "^1.1.1"
 pydantic = "^2.4.2"
 vdom = "^1.0.0"
@@ -60,7 +60,7 @@ pre-commit = "^3.2.2"
 toml = "^0.10.2"
 bump2version = "^1.0.1"
 jinja2 = "^3.1.2"
-ipykernel = ">=6.0.0,<8.0.0"
+ipykernel = ">=6.0.0"
 types-toml = "^0.10.8.6"
 pandas = "^2.0.2"
 pytest-asyncio = "^0.21.1"


### PR DESCRIPTION
When starting a new `poetry` project with chatlab I kept running into issues with the tightness on the version.