### PR TITLE
fix up the auto-changelog-documenting

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ current_version = 1.0.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:pyproject.toml]
@@ -14,6 +14,7 @@ replace = version = "{new_version}"
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
-[bumpversion:file:CHANGELOG.md]
-search = ## [{current_version}]
-replace = ## [{new_version}]
+# For use during pre-releases
+# [bumpversion:file:CHANGELOG.md]
+# search = ## [{current_version}]
+# replace = ## [{new_version}]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.1]
 
+### Documented
+
+- New Knowledge Graph example
+- Switched all docs to [chatlab.dev](https://chatlab.dev)
+- No more `--pre` required for installs
+
+
+## [1.0.0]
+
+
 ### Added
 
 -   📚 Documentation now available at [chatlab.dev](https://chatlab.dev)


### PR DESCRIPTION
Last release didn't get the right changelog bits. Putting it all back to normal now that we're out of pre-release mode.