### PR TITLE
append messages right after request made

### DIFF
--- a/chatlab/chat.py
+++ b/chatlab/chat.py
@@ -246,6 +246,8 @@ class Chat:
                     temperature=kwargs.get("temperature", 0),
                 )
 
+                self.append(*messages)
+
                 finish_reason, function_call_request = await self.__process_stream(streaming_response)
             else:
                 full_response = await client.chat.completions.create(
@@ -255,6 +257,8 @@ class Chat:
                     stream=False,
                     temperature=kwargs.get("temperature", 0),
                 )
+
+                self.append(*messages)
 
                 (
                     finish_reason,
@@ -267,8 +271,6 @@ class Chat:
             await self.submit(*messages, stream=stream, **kwargs)
 
             return
-
-        self.append(*messages)
 
         if finish_reason == "function_call":
             if function_call_request is None:


### PR DESCRIPTION
🐛  Messages from the user were placed _after_ the assistant response. This was originally in place to handle when there were 429s or other request failures so that messages wouldn't append if OpenAI wasn't responding well. Turns out this broke the main working case.