### PR TITLE
Custom Servers -- allow passing through base url and api key

### DIFF
--- a/notebooks/open-model-functions.ipynb
+++ b/notebooks/open-model-functions.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "sql.query(\"select count(*) from products order by count desc limit 10\")"
+      ],
+      "text/plain": [
+       "sql.query(\"select count(*) from products order by count desc limit 10\")"
+      ]
+     },
+     "metadata": {
+      "text/markdown": {
+       "chatlab": {
+        "default": true
+       }
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from chatlab import Chat, system\n",
+    "\n",
+    "chat = Chat(\n",
+    "    system(\"You are a data engineer\"),\n",
+    "    model=\"gorilla-openfunctions-v0\",\n",
+    "    base_url=\"http://luigi.millennium.berkeley.edu:8000/v1\",\n",
+    "    api_key=\"EMPTY\",\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def sql(query: str):\n",
+    "    \"\"\"Runs SQL query\"\"\"\n",
+    "    # Totally fake, returns an empty table for demonstration\n",
+    "\n",
+    "    return []\n",
+    "\n",
+    "\n",
+    "chat.register(sql)\n",
+    "\n",
+    "await chat(\"Show me the top 10 most popular products\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "chatlab-3kMKfU-i-py3.11",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This allows chatlab to connect up to custom deployed LLMs that obey the OpenAI API, like [Gorilla](https://github.com/ShishirPatil/gorilla). This model understands the function definitions. However, the responses we get from the model are only raw assistant messages -- not the OpenAI function calling API.

<img width="682" alt="image" src="https://github.com/rgbkrk/chatlab/assets/836375/c090c41b-88ee-4ee2-b02d-129ff07c0135">
