### PR TITLE
Adding January 2024 ChatGPT models

### DIFF
--- a/chatlab/models.py
+++ b/chatlab/models.py
@@ -5,7 +5,8 @@ from enum import Enum
 
 class ChatModel(Enum):
     """Models available for use with chatlab."""
-
+    GPT_4_TURBO_PREVIEW = "gpt-4-turbo-preview"
+    GPT_4_0125_PREVIEW = "gpt-4-0125-preview"
     GPT_4_1106_PREVIEW = "gpt-4-1106-preview"
     GPT_4_VISION_PREVIEW = "gpt-4-vision-preview"
 
@@ -17,6 +18,7 @@ class ChatModel(Enum):
     GPT_3_5_TURBO_0613 = "gpt-3.5-turbo-0613"
     GPT_3_5_TURBO_16K = "gpt-3.5-turbo-16k"
     GPT_3_5_TURBO_16K_0613 = "gpt-3.5-turbo-16k-0613"
+    GPT_3_5_TURBO_0125 = "gpt-3.5-turbo-0125"
 
 
 #
@@ -43,6 +45,9 @@ GPT_3_5_TURBO = ChatModel.GPT_3_5_TURBO.value
 GPT_3_5_TURBO_0613 = ChatModel.GPT_3_5_TURBO_0613.value
 GPT_3_5_TURBO_16K = ChatModel.GPT_3_5_TURBO_16K.value
 GPT_3_5_TURBO_16K_0613 = ChatModel.GPT_3_5_TURBO_16K_0613.value
+GPT_3_5_TURBO_0125 = ChatModel.GPT_3_5_TURBO_0125.value
 
+GPT_4_TURBO_PREVIEW = ChatModel.GPT_4_TURBO_PREVIEW.value
+GPT_4_0125_PREVIEW = ChatModel.GPT_4_0125_PREVIEW.value
 GPT_4_1106_PREVIEW = ChatModel.GPT_4_1106_PREVIEW.value
 GPT_4_VISION_PREVIEW = ChatModel.GPT_4_VISION_PREVIEW.value

--- a/chatlab/models.py
+++ b/chatlab/models.py
@@ -21,21 +21,6 @@ class ChatModel(Enum):
     GPT_3_5_TURBO_0125 = "gpt-3.5-turbo-0125"
 
 
-#
-# From https://platform.openai.com/docs/guides/gpt/function-calling, the docs say
-# that gpt-3.5-turbo-0613 and gpt-4-0613 models support function calling.
-# Experimentally, gpt-3.5-turbo-16k also supports function calling.
-#
-# TODO: Determine if gpt-4-32k supports function calling.
-#
-class FunctionCompatibleModel(Enum):
-    """Models available for use with chatlab."""
-
-    GPT_3_5_TURBO_0613 = "gpt-3.5-turbo-0613"
-    GPT_3_5_TURBO_16K_0613 = "gpt-3.5-turbo-16k-0613"
-    GPT_4_0613 = "gpt-4-0613"
-
-
 # Exporting for the convenience of typing e.g. models.GPT_4_0613
 GPT_4 = ChatModel.GPT_4.value
 GPT_4_0613 = ChatModel.GPT_4_0613.value


### PR DESCRIPTION
Adding in the -0125 models. However, I did not touch the `FunctionCompatibleModel` enum, as I couldn't find it used anywhere in the code, and it doesn't look like it's been kept up to date. @rgbkrk should that enum be removed?