### PR TITLE
show chat models exceptions by default

### DIFF
--- a/chatlab/decorators.py
+++ b/chatlab/decorators.py
@@ -36,8 +36,20 @@ from pydantic import BaseModel
 
 class ChatlabMetadata(BaseModel):
     """ChatLab metadata for a function."""
-    expose_exception_to_llm: bool = False
+    expose_exception_to_llm: bool = True
     render: Optional[Callable] = None
+    bubble_exceptions: bool = False
+
+def bubble_exceptions(func):
+    if not hasattr(func, "chatlab_metadata"):
+        func.chatlab_metadata = ChatlabMetadata()
+
+    # Make sure that chatlab_metadata is an instance of ChatlabMetadata
+    if not isinstance(func.chatlab_metadata, ChatlabMetadata):
+        raise Exception("func.chatlab_metadata must be an instance of ChatlabMetadata")
+
+    func.chatlab_metadata.bubble_exceptions = True
+    return func
 
 def expose_exception_to_llm(func):
     """Expose exceptions from calling the function to the LLM.

--- a/chatlab/views/tools.py
+++ b/chatlab/views/tools.py
@@ -145,8 +145,7 @@ class ToolArguments(AutoUpdate):
             # If not, then we just raise it and let the user handle it.
             chatlab_metadata = function_registry.get_chatlab_metadata(function_name)
 
-            if not chatlab_metadata.expose_exception_to_llm:
-                # Bubble up the exception to the user
+            if chatlab_metadata.bubble_exceptions:
                 raise
 
             repr_llm = repr(e)


### PR DESCRIPTION
This switches chatlab over to exposing exceptions to LLMs by default and bubbling it up only if requested (useful for trial and error as a human).